### PR TITLE
Add provision to customize feed templates

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,6 +21,11 @@ feeds:
   json: true
   atom: true
 
+#templates:
+#  rss: "@theme/partials/feeds/rss.xml.twig"
+#  json: "@theme/partials/feeds/json.twig"
+#  atom: "@theme/partials/feeds/atom.xml.twig"
+
 # Autodiscovery allows Feed aggregators to find your feeds more easily.
 autodiscovery: true
 

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -26,21 +26,28 @@ class Controller extends ExtensionController
         }
 
         if ($type === 'rss') {
-            $template = '@rss-extension/rss.xml.twig';
+            $template = isset($config['templates']['rss'])
+            ? $config['templates']['rss']
+            : '@rss-extension/rss.xml.twig';
+
             if (!empty($config['rss_template'])) {
                 $template = $config['rss_template'];
             }
             $headerContentType = 'application/rss+xml;charset=UTF-8';
         } elseif ($type === 'atom') {
-            $template = '@rss-extension/atom.xml.twig';
+            $template = isset($config['templates']['atom'])
+            ? $config['templates']['atom']
+            : '@rss-extension/atom.xml.twig';
 
             if (!empty($config['atom_template'])) {
                 $template = $config['atom_template'];
             }
             $headerContentType = 'application/atom+xml;charset=UTF-8';
         } else {
-            $template = '@rss-extension/json.twig';
-
+            $template = isset($config['templates']['json'])
+            ? $config['templates']['json']
+            : '@rss-extension/json.twig';
+            
             if (!empty($config['json_template'])) {
                 $template = $config['json_template'];
             }


### PR DESCRIPTION
Make it possible for users to customize feed templates within the site theme, as the defaults may have feed options that or not needed, or required options that are not set up in the templates.